### PR TITLE
Hotfix dbUpsertTable function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dbUpsert
 Type: Package
 Title: SQL DB Update-And-Insert (upsert)
-Version: 0.1.1
+Version: 0.1.2
 Author: Tyler Neumann
 Maintainer: Tyler Neumann <neumanntylers@gmail.com>
 Description: This package leverages RDBMS specific implementations to handle Upserts.

--- a/R/dbUpsertTable.R
+++ b/R/dbUpsertTable.R
@@ -48,7 +48,7 @@ dbUpsertTable <- function(
   ##############################################################################
   # Get primary key column(s) from table
   ##############################################################################
-  if (is.na(value_pkey)) {
+  if (any(is.na(value_pkey))) {
     if (verbose == TRUE) {
       cat("Querying table primary key columns\n")
     }


### PR DESCRIPTION
Fixed issue when value_pkey is a character vector with length > 1:
![image](https://github.com/timeddilation/dbUpsert/assets/45134150/99d2f3b3-495a-4a67-bc70-f421cbb62a99)
